### PR TITLE
Revert "Allow BRBDT's to return structured validation responses"

### DIFF
--- a/src/brb_data_type.rs
+++ b/src/brb_data_type.rs
@@ -7,13 +7,12 @@ use crate::Actor;
 
 pub trait BRBDataType: Debug {
     type Op: Debug + Clone + Hash + Eq + Serialize;
-    type Validation: Debug + 'static;
 
     /// initialize a new replica of this datatype
     fn new(actor: Actor) -> Self;
 
     /// Protection against Byzantines
-    fn validate(&self, source: &Actor, op: &Self::Op) -> Result<(), Self::Validation>;
+    fn validate(&self, from: &Actor, op: &Self::Op) -> bool;
 
     /// Executed once an op has been validated
     fn apply(&mut self, op: Self::Op);


### PR DESCRIPTION
Reverts maidsafe/brb#9

I think this needs further discussion. Adding Generics to an Error is likely to cause many issues using this. 