### PR TITLE
doc/all: documenting and cleanup.

### DIFF
--- a/src/brb_data_type.rs
+++ b/src/brb_data_type.rs
@@ -1,18 +1,43 @@
+// Copyright 2021 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// http://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+//! The purpose of BRB is to provide a BFT transport for CRDT-esque Data Types.
+//!
+//! The BRBDataType trait defines the contract such Data Types must fulfill.
+//! Typically, an existing CRDT algorithm wiil be wrapped by a struct that
+//! implements this trait.
+//!
+//! Examples of types that implement BRBDataType:
+//!   brb_dt_orswot, brb_dt_at2, brb_dt_tree
+
+use std::error::Error;
 use std::fmt::Debug;
 use std::hash::Hash;
 
 use serde::Serialize;
 
+/// The BRBDataType trait
 pub trait BRBDataType<A>: Debug {
+    /// The set of ops this data type accepts
     type Op: Debug + Clone + Hash + Eq + Serialize;
-    type ValidationError: Debug + 'static;
+
+    /// A validation error specific to this data type.
+    type ValidationError: Debug + Error + 'static;
 
     /// initialize a new replica of this datatype
     fn new(actor: A) -> Self;
 
     /// Protection against Byzantines
+    /// Validate any incoming operations, here you must perform your byzantine fault
+    /// tolerance checks specific to your algorithm    
     fn validate(&self, source: &A, op: &Self::Op) -> Result<(), Self::ValidationError>;
 
-    /// Executed once an op has been validated
+    /// Execute an op after it has been validated.
     fn apply(&mut self, op: Self::Op);
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,14 @@
+// Copyright 2021 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// http://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+//! Provides BRB specific errors.
+
 use std::collections::BTreeSet;
 
 use brb_membership::signature;
@@ -5,56 +16,119 @@ use brb_membership::{Actor, Generation, Sig};
 use crdts::Dot;
 use thiserror::Error;
 
+use core::fmt;
+use std::error;
+
+/// Enumerates the error conditions that can occur during BRB processing.
 #[derive(Error, Debug)]
-pub enum Error<A: Actor<S> + 'static, S: Sig + 'static, V: core::fmt::Debug + 'static> {
+pub enum Error<A: Actor<S> + 'static, S: Sig + 'static, V: fmt::Debug + error::Error + 'static> {
+    /// error while processing membership change
     #[error("error while processing membership change")]
     Membership(#[from] brb_membership::Error<A, S>),
+
+    /// Failed to serialize all or part of a packet
     #[error("Failed to serialize all or part of a packet")]
     Encoding(#[from] bincode::Error),
+
+    /// Packet failed validation
     #[error("Packet failed validation")]
     Validation(#[from] ValidationError<A, S, V>),
+
+    /// Failure when working with signature
     #[error("Failure when working with signature")]
     Signature(#[from] signature::Error),
 }
 
+/// Enumerates types of packet validation errors.
+///
+/// Note that all of these errors are generated within the BRB module
+/// itself with the exception of DataTypeFailedValidation, which occurs
+/// when a BRBDataType validation fails according to its own internal logic.
 #[derive(Error, Debug)]
-pub enum ValidationError<A: Actor<S> + 'static, S: Sig + 'static, V: core::fmt::Debug> {
+pub enum ValidationError<
+    A: Actor<S> + 'static,
+    S: Sig + 'static,
+    V: fmt::Debug + error::Error + 'static,
+> {
+    /// The actor who sent this packet is different from the actor who incremented the dot
     #[error("The actor `{from}` who sent this packet is different from the actor who incremented the dot: `{dot:?}`")]
-    PacketSourceIsNotDot { from: A, dot: Dot<A> },
+    PacketSourceIsNotDot {
+        /// actor who sent the packet
+        from: A,
+        /// the associated dot
+        dot: Dot<A>,
+    },
+
+    /// The dot in this message is out of order
     #[error("The dot in this message `{msg_dot:?}` is out of order (expected: {expected_dot:?})")]
     MsgDotNotTheNextDot {
+        /// dot of the message
         msg_dot: Dot<A>,
+        /// dot that was expected
         expected_dot: Dot<A>,
     },
+
+    /// The source of this message already has a pending message, we can not start a new operation until the first one has completed
     #[error("The source of this message already has a pending message, we can not start a new operation until the first one has completed")]
     SourceAlreadyHasPendingMsg {
+        /// dot of the message
         msg_dot: Dot<A>,
+        /// dot of next delivery
         next_deliver_dot: Dot<A>,
     },
+
+    /// This message is not from this generation
     #[error("This message is not from this generation {msg_gen} (expected: {gen})")]
     MessageFromDifferentGeneration {
+        /// generation of the message
         msg_gen: Generation,
+        /// present generation
         gen: Generation,
     },
+
+    /// Source is not a voting member
     #[error("Source is not a voting member ({from:?} not in {members:?})")]
-    SourceIsNotVotingMember { from: A, members: BTreeSet<A> },
-    #[error("the datatype failed to validated the operation")]
+    SourceIsNotVotingMember {
+        /// actor that proposed the action
+        from: A,
+        /// voting members
+        members: BTreeSet<A>,
+    },
+
+    /// the datatype failed to validate the operation
+    #[error("the datatype failed to validate the operation")]
     DataTypeFailedValidation(V),
+
+    /// Signature is invalid
     #[error("Signature is invalid")]
     InvalidSignature,
+
+    /// We received a SignedValidated packet for a message we did not request
     #[error("We received a SignedValidated packet for a message we did not request")]
     SignedValidatedForPacketWeDidNotRequest,
+
+    /// Message dot to be applied is not the next message to be delivered
     #[error("Message dot {msg_dot:?} to be applied is not the next message to be delivered (expected: {expected_dot:?}")]
     MsgDotNotNextDotToBeDelivered {
+        /// the dot in the msg
         msg_dot: Dot<A>,
+        /// the dot we are expecting
         expected_dot: Dot<A>,
     },
+
+    /// The proof did not contain enough signatures to form quorum
     #[error("The proof did not contain enough signatures to form quorum")]
     NotEnoughSignaturesToFormQuorum,
+
+    /// Proof contains signatures from non-members
     #[error("Proof contains signatures from non-members")]
     ProofContainsSignaturesFromNonMembers,
+
+    /// Proof contains invalid signatures
     #[error("Proof contains invalid signatures")]
     ProofContainsInvalidSignatures,
+
+    /// Phantom, unused.
     #[error("This variant is only here to satisfy the type checker (we need to use S in a field)")]
     PhantomSig(core::marker::PhantomData<S>),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,15 @@
-// #![deny(missing_docs)]
+// Copyright 2021 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// http://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+//! BRB - Byzantine Reliable Broadcast
+
+#![deny(missing_docs)]
 
 // re-export these
 pub use brb_membership as membership;

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -1,23 +1,47 @@
+// Copyright 2021 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// http://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+//! BRB uses Packet and Payload types that are not specific to any network transport
+//! layer such as tcp/ip. As such, BRB may easily be adapted to work over various
+//! transports.
+
 use serde::{Deserialize, Serialize};
 
 use crate::deterministic_brb;
 use crate::{Actor, Sig};
 
+/// Represents a logical message packet with a BRB specific payload.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Packet<A: Actor<S>, S: Sig, Op> {
+    /// source actor
     pub source: A,
+    /// destination actor
     pub dest: A,
+    /// payload data
     pub payload: Payload<A, S, Op>,
+    /// signature of payload data by source actor
     pub sig: S,
 }
 
+/// Enumerates types of BRB data that may be included in a Packet.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Payload<A: Actor<S>, S: Sig, DataTypeOp> {
+    /// Represents an AntiEntropy request
     AntiEntropy {
+        /// last-seen generation
         generation: brb_membership::Generation,
+        /// delivered clock
         delivered: crdts::VClock<A>,
     },
+    /// Represents a BRB operation
     BRB(deterministic_brb::Op<A, S, DataTypeOp>),
     // Box to avoid https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant
+    /// Represents a brb_membership Vote
     Membership(Box<brb_membership::Vote<A, S>>),
 }


### PR DESCRIPTION
* Adds maidsafe copyright notice to *.rs
* Adds #![deny(missing_docs)] to lib.rs
* Adds comment docs for all structs/enums/code
* Adds std::error::Error trait as requirement for BRBDataType::validate()
* renames DeterministicBRB::quorum() to supermajority()