### PR TITLE
Delivery confirmation

### DIFF
--- a/src/deterministic_brb.rs
+++ b/src/deterministic_brb.rs
@@ -43,6 +43,7 @@ pub struct DeterministicBRB<A: Actor<S>, SA: SigningActor<A, S>, S: Sig, BRBDT: 
 
     /// Msgs this process has sent ProofOfAgreement for but has not yet received a
     /// super-majority of delivery confirmations.
+    #[allow(clippy::type_complexity)]
     pub pending_delivery: HashMap<Msg<A, BRBDT::Op>, (BTreeMap<A, S>, BTreeSet<A>)>,
 
     /// The clock representing the most recently received messages from each process.

--- a/src/deterministic_brb.rs
+++ b/src/deterministic_brb.rs
@@ -246,6 +246,26 @@ impl<A: Actor<S>, SA: SigningActor<A, S>, S: Sig, BRBDT: BRBDataType<A>>
     }
 
     /// Initiates an operation for the BRBDataType being secured by BRB.
+    ///
+    /// NOTE: Network members will refuse to sign multiple operations from a
+    ///       source concurrently. It's recommended to ensure there aren't any
+    ///       pending deliveries before you initiate a new operation to reduce
+    ///       the chance of this happening.
+    ///
+    ///       A naive implementation of this would be:
+    ///
+    /// ``` rust
+    /// let mut packets_to_resend = brb.resend_pending_deliveries()?;
+    /// while !packets_to_resend.is_empty() {
+    ///    // ... re-send these packets
+    ///    network.send_packets(packets_to_resend);
+    ///    sleep(TIMEOUT_SECONDS);
+    ///    packets_to_resend = brb.resend_pending_deliveries()?;
+    /// }
+    ///
+    /// brb.exec_op()?;
+    /// ```
+
     #[allow(clippy::type_complexity)]
     pub fn exec_op(
         &self,

--- a/src/deterministic_brb.rs
+++ b/src/deterministic_brb.rs
@@ -225,6 +225,7 @@ impl<A: Actor<S>, SA: SigningActor<A, S>, S: Sig, BRBDT: BRBDataType<A>>
     }
 
     /// Resend any proof of agreements that we have not yet received delivery confirmation for.
+    #[allow(clippy::type_complexity)]
     pub fn resend_pending_deliveries(
         &self,
     ) -> Result<Vec<Packet<A, S, BRBDT::Op>>, Error<A, S, BRBDT::ValidationError>> {

--- a/src/deterministic_brb.rs
+++ b/src/deterministic_brb.rs
@@ -251,11 +251,11 @@ impl<A: Actor<S>, SA: SigningActor<A, S>, S: Sig, BRBDT: BRBDataType<A>>
     ///       source concurrently. It's recommended to ensure there aren't any
     ///       pending deliveries before you initiate a new operation to reduce
     ///       the chance of this happening.
-    ///
     ///       A naive implementation of this would be:
     ///
-    /// ``` rust
+    /// ```ignore
     /// let mut packets_to_resend = brb.resend_pending_deliveries()?;
+    ///
     /// while !packets_to_resend.is_empty() {
     ///    // ... re-send these packets
     ///    network.send_packets(packets_to_resend);
@@ -263,7 +263,7 @@ impl<A: Actor<S>, SA: SigningActor<A, S>, S: Sig, BRBDT: BRBDataType<A>>
     ///    packets_to_resend = brb.resend_pending_deliveries()?;
     /// }
     ///
-    /// brb.exec_op()?;
+    /// brb.exec_op(op)?;
     /// ```
 
     #[allow(clippy::type_complexity)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -128,6 +128,17 @@ pub enum ValidationError<
     #[error("Proof contains invalid signatures")]
     ProofContainsInvalidSignatures,
 
+    /// We received a Op::Delivered packet for a message we did not initiate. Only the initiator should
+    /// receive these delivered packets.
+    #[error("We did not initiate this msg so we shouldn't be notified that it was delivered")]
+    DeliveredForPacketWeDidNotInitiate,
+
+    /// We received an Op::Delivered packet for a message we are no longer waiting on.
+    /// This can happen when we've already received a super-majority of Delivered packets and have
+    /// cleared our local buffer.
+    #[error("We are no longer waiting for delivery notifications for this packet")]
+    DeliveredForPacketWeAreNotWaitingOn,
+
     /// Phantom, unused.
     #[error("This variant is only here to satisfy the type checker (we need to use S in a field)")]
     PhantomSig(core::marker::PhantomData<S>),

--- a/src/net.rs
+++ b/src/net.rs
@@ -99,7 +99,7 @@ impl<DT: BRBDT> Net<DT> {
         actor
     }
 
-    /// Get a (mutable) reference to a proc with the given actor.
+    /// Get a (immutable) reference to a proc with the given actor.
     pub fn proc(&self, actor: &Actor) -> Option<&State<DT>> {
         self.procs
             .iter()

--- a/tests/deterministic_brb.rs
+++ b/tests/deterministic_brb.rs
@@ -1,0 +1,160 @@
+use core::convert::Infallible;
+use std::collections::BTreeSet;
+
+use brb::{
+    deterministic_brb::{Msg, Op},
+    net::{Actor, Net},
+    BRBDataType, Payload,
+};
+use crdts::Dot;
+
+#[derive(Debug)]
+struct TestDT {
+    actor: Actor,
+    set: BTreeSet<u8>,
+}
+
+impl BRBDataType<Actor> for TestDT {
+    type Op = u8;
+    type ValidationError = Infallible;
+
+    fn new(actor: Actor) -> Self {
+        let set = Default::default();
+        TestDT { actor, set }
+    }
+
+    fn validate(&self, _source: &Actor, _op: &Self::Op) -> Result<(), Self::ValidationError> {
+        Ok(())
+    }
+
+    fn apply(&mut self, op: Self::Op) {
+        self.set.insert(op);
+    }
+}
+
+type TestNet = Net<TestDT>;
+
+#[test]
+fn test_sender_receives_confirmation_after_member_applies_operation() -> Result<(), &'static str> {
+    let mut net = TestNet::new();
+    let actor_a = net.initialize_proc();
+    let actor_b = net.initialize_proc();
+
+    let a_proc = net.proc_mut(&actor_a).ok_or("No proc for actor_a")?;
+    a_proc.force_join(actor_a);
+    a_proc.force_join(actor_b);
+
+    let b_proc = net.proc_mut(&actor_b).ok_or("No proc for actor_b")?;
+    b_proc.force_join(actor_a);
+    b_proc.force_join(actor_b);
+
+    let packets = net
+        .proc(&actor_a)
+        .ok_or("No proc for actor_a")?
+        .exec_op(32u8)
+        .map_err(|_| "Failed to generate insert op")?;
+
+    let expected_msg = Msg {
+        gen: 0,
+        op: 32u8,
+        dot: Dot::new(actor_a, 1),
+    };
+
+    let expected_op = Op::RequestValidation {
+        msg: expected_msg.clone(),
+    };
+    assert_eq!(
+        packets
+            .iter()
+            .cloned()
+            .filter_map(|packet| match packet.payload {
+                Payload::BRB(msg) => Some(msg),
+                _ => None,
+            })
+            .collect::<Vec<_>>(),
+        vec![expected_op.clone(), expected_op]
+    );
+
+    let mut sig_packets = Vec::new();
+    for packet in packets {
+        sig_packets.extend(net.deliver_packet(packet));
+    }
+
+    assert_eq!(sig_packets.len(), 2); // Should recieve two signatures back.
+    let sig_packet_1 = sig_packets.pop().ok_or("Failed to pop packet")?;
+    let sig_packet_2 = sig_packets.pop().ok_or("Failed to pop packet")?;
+
+    assert_eq!(net.deliver_packet(sig_packet_1), vec![]);
+    let proof_of_agreement_packets = net.deliver_packet(sig_packet_2);
+    assert_eq!(proof_of_agreement_packets.len(), 2);
+
+    let mut delivery_confirmation_packets = vec![];
+    for packet in proof_of_agreement_packets.clone() {
+        let confirmed_delivered_packets = net.deliver_packet(packet);
+        assert_eq!(confirmed_delivered_packets.len(), 1);
+        assert_eq!(
+            confirmed_delivered_packets
+                .iter()
+                .cloned()
+                .filter_map(|p| match p.payload {
+                    Payload::BRB(op) => Some(op),
+                    _ => None,
+                })
+                .collect::<Vec<_>>(),
+            vec![Op::Delivered {
+                msg: expected_msg.clone()
+            }]
+        );
+        delivery_confirmation_packets.extend(confirmed_delivered_packets);
+    }
+
+    assert_eq!(delivery_confirmation_packets.len(), 2);
+    let delivery_packet_1 = delivery_confirmation_packets
+        .pop()
+        .ok_or("Failed to pop delivery packet")?;
+    let delivery_packet_2 = delivery_confirmation_packets
+        .pop()
+        .ok_or("Failed to pop delivery packet")?;
+
+    // If we resend any pending deliveries now, they should match the proof of agreement packets
+    // we saw previously.
+    assert_eq!(
+        net.proc(&actor_a)
+            .ok_or("No proc for actor_a")?
+            .resend_pending_deliveries()
+            .map_err(|_| "Failed to resend pending deliveries")?,
+        proof_of_agreement_packets
+    );
+    assert_eq!(net.deliver_packet(delivery_packet_1.clone()), vec![]);
+
+    // Now, we should only resend the PoA for the one packet we did not receive a delivery packet from.
+    assert_eq!(
+        net.proc(&actor_a)
+            .ok_or("No proc for actor_a")?
+            .resend_pending_deliveries()
+            .map_err(|_| "Failed to resend pending deliveries")?,
+        proof_of_agreement_packets
+            .into_iter()
+            .filter(|p| p.dest != delivery_packet_1.source)
+            .collect::<Vec<_>>()
+    );
+
+    assert_eq!(net.deliver_packet(delivery_packet_2), vec![]);
+
+    assert_eq!(
+        net.proc(&actor_a)
+            .ok_or("No proc for actor_a")?
+            .resend_pending_deliveries()
+            .map_err(|_| "Failed to resend pending deliveries")?,
+        vec![]
+    );
+
+    // Make sure we actually arrived at the correct final state.
+    assert!(net.members_are_in_agreement());
+    assert_eq!(
+        net.proc(&actor_a).ok_or("No proc for actor_a")?.dt.set,
+        vec![32u8].into_iter().collect()
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
This adds one more phase to BRB after ProofOfAgreement for delivery confirmation.

We also add an API to re-send ProofOfAgreements to those members who have not sent us delivery confirmation.